### PR TITLE
refactor(ui): Hide controls during processing

### DIFF
--- a/ImageProcessor.UI/Views/MainWindow.axaml
+++ b/ImageProcessor.UI/Views/MainWindow.axaml
@@ -70,15 +70,18 @@
 
                     <Separator Margin="0,5"/>
 
-                    <StackPanel Orientation="Horizontal" Spacing="10" IsEnabled="{Binding IsUiEnabled}">
+                    <StackPanel Orientation="Horizontal" Spacing="10" IsVisible="{Binding IsUiEnabled}">
                         <TextBlock Text="AI Model:" Classes="label"/>
                         <ComboBox ItemsSource="{Binding Models}" SelectedItem="{Binding SelectedModel}" MinWidth="200"/>
                     </StackPanel>
 
                     <Separator Margin="0,5"/>
 
-                    <TextBlock Text="Processing Options" FontWeight="Bold" IsEnabled="{Binding IsUiEnabled}"/>
-                    <CheckBox Content="Show Preview" IsChecked="{Binding ShowPreview}"/>
+                    <TextBlock Text="Processing Options" FontWeight="Bold" IsVisible="{Binding IsUiEnabled}"/>
+                    <StackPanel Orientation="Horizontal" Spacing="10" IsVisible="{Binding IsUiEnabled}">
+                        <TextBlock Text="Show Preview" VerticalAlignment="Center"/>
+                        <ToggleSwitch IsChecked="{Binding ShowPreview}"/>
+                    </StackPanel>
                     <WrapPanel Orientation="Horizontal" IsVisible="{Binding IsUiEnabled}">
                         <CheckBox Content="Apply 4x Upscale" IsChecked="{Binding ApplyUpscale}"/>
                         <CheckBox Content="Convert to .WebP" IsChecked="{Binding ConvertToWebP}"/>


### PR DESCRIPTION
- The model selection ComboBox and the processing options are now hidden when processing is active.

- This is done by binding the IsVisible property to IsUiEnabled.