### PR TITLE
feat(ui): Implement drag and drop for input folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ intrucciones_git.txt
 errors.txt
 image-processor-web/node_modules
 publish/
+"processing_log_*.csv" 

--- a/ImageProcessor.UI/Views/MainWindow.axaml
+++ b/ImageProcessor.UI/Views/MainWindow.axaml
@@ -8,13 +8,17 @@
         x:DataType="vm:MainWindowViewModel"
         WindowStartupLocation="CenterScreen"
         Title="Image Enhancer AI (.NET Edition)"
-        Width="900" Height="750" MinWidth="900" MinHeight="750">
+        Width="900" Height="750" MinWidth="900" MinHeight="750"
+        DragDrop.DragOver="OnDragOver"
+        DragDrop.DragLeave="OnDragLeave"
+        DragDrop.Drop="OnDrop">
 
     <Design.DataContext>
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 
-    <Grid RowDefinitions="Auto,*" Margin="15">
+    <Border Name="DropTargetBorder" BorderThickness="2" BorderBrush="Transparent">
+        <Grid RowDefinitions="Auto,*" Margin="15">
 
         <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="5" HorizontalAlignment="Right">
             <TextBlock Text="Dark Theme"/>
@@ -186,5 +190,6 @@
                 </StackPanel>
             </Border>
         </Grid>
-    </Grid>
-</Window>
+            </Grid>
+        </Border>
+    </Window>

--- a/ImageProcessor.UI/Views/MainWindow.axaml.cs
+++ b/ImageProcessor.UI/Views/MainWindow.axaml.cs
@@ -3,7 +3,12 @@ using Avalonia.Controls;
 using ImageProcessor.UI.ViewModels;
 using System;
 using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Platform.Storage;
 
 namespace ImageProcessor.UI.Views;
 
@@ -20,6 +25,12 @@ public partial class MainWindow : Window
         InitializeComponent();
         DataContext = viewModel;
 
+        var border = this.FindControl<Border>("DropTargetBorder");
+        if (border != null)
+        {
+            DragDrop.SetAllowDrop(border, true);
+        }
+
         var exitButton = this.FindControl<Button>("ExitButton");
         if (exitButton != null)
         {
@@ -29,6 +40,51 @@ public partial class MainWindow : Window
         // Handle the Loaded event to manually set the top position
         Loaded += OnLoaded;
         Closing += OnClosing;
+    }
+
+    private void OnDragOver(object? sender, DragEventArgs e)
+    {
+        // Check if the dragged data contains files or folders
+        if (e.Data.Contains(DataFormats.Files))
+        {
+            e.DragEffects = DragDropEffects.Copy;
+            DropTargetBorder.BorderBrush = Brushes.DodgerBlue; // Visual feedback
+        }
+        else
+        {
+            e.DragEffects = DragDropEffects.None;
+        }
+    }
+
+    private void OnDragLeave(object? sender, DragEventArgs e)
+    {
+        DropTargetBorder.BorderBrush = Brushes.Transparent; // Reset visual feedback
+    }
+
+    private void OnDrop(object? sender, DragEventArgs e)
+    {
+        DropTargetBorder.BorderBrush = Brushes.Transparent; // Reset visual feedback
+
+        if (e.Data.GetFiles() is { } files && files.Any())
+        {
+            var path = files.First().TryGetLocalPath();
+            if (path != null)
+            {
+                if (DataContext is MainWindowViewModel vm)
+                {
+                    // If the dropped item is a file, use its parent directory.
+                    // If it's a directory, use the directory itself.
+                    if (File.Exists(path))
+                    {
+                        vm.InputFolder = Path.GetDirectoryName(path) ?? string.Empty;
+                    }
+                    else if (Directory.Exists(path))
+                    {
+                        vm.InputFolder = path;
+                    }
+                }
+            }
+        }
     }
 
     private void OnLoaded(object? sender, EventArgs e)


### PR DESCRIPTION
Adds the ability for users to drag and drop a folder or a file onto the main window to set the input folder.

The drop area is the entire main content section.

If a file is dropped, its parent directory is used as the input folder.

Also adds processing log files (*.csv) to .gitignore.