### PR TITLE
feat(ui): Add configurable quality sliders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,4 +94,4 @@ intrucciones_git.txt
 errors.txt
 image-processor-web/node_modules
 publish/
-"processing_log_*.csv" 
+processing_log_*.csv

--- a/ImageProcessor.Core/ImageProcessorService.cs
+++ b/ImageProcessor.Core/ImageProcessorService.cs
@@ -291,13 +291,17 @@ public class ImageProcessorService
 
         string sourceForConversion = options.ApplyUpscale && File.Exists(improvedPngPath) ? improvedPngPath : file.FullName;
 
+        // AVIF CRF scale is 0-63, where 0 is best quality.
+        // We map our 0-100 UI quality (where 100 is best) to the CRF scale.
+        int avifCrf = 63 - (int)Math.Round(options.AvifQuality * 63.0 / 100.0);
+
         if (options.ConvertToWebP && options.ConvertToAvif)
         {
-            await RunProcessAsync(_cwebpExecutablePath, $"-q 80 \"{sourceForConversion}\" -o \"{intermediateWebPPath}\"", cancellationToken);
+            await RunProcessAsync(_cwebpExecutablePath, $"-q {options.WebPQuality} \"{sourceForConversion}\" -o \"{intermediateWebPPath}\"", cancellationToken);
 
             if (File.Exists(intermediateWebPPath))
             {
-                await RunProcessAsync(_ffmpegExecutablePath, $"-y -i \"{intermediateWebPPath}\" -c:v libaom-av1 -still-picture 1 -crf 35 -b:v 0 -cpu-used 4 -threads 8 \"{finalAvifPath}\"", cancellationToken);
+                await RunProcessAsync(_ffmpegExecutablePath, $"-y -i \"{intermediateWebPPath}\" -c:v libaom-av1 -still-picture 1 -crf {avifCrf} -b:v 0 -cpu-used 4 -threads 8 \"{finalAvifPath}\"", cancellationToken);
                 if (File.Exists(finalAvifPath))
                 {
                     finalSize = new FileInfo(finalAvifPath).Length;
@@ -308,7 +312,7 @@ public class ImageProcessorService
         }
         else if (options.ConvertToWebP)
         {
-            await RunProcessAsync(_cwebpExecutablePath, $"-q 80 \"{sourceForConversion}\" -o \"{finalWebPPath}\"", cancellationToken);
+            await RunProcessAsync(_cwebpExecutablePath, $"-q {options.WebPQuality} \"{sourceForConversion}\" -o \"{finalWebPPath}\"", cancellationToken);
             if (File.Exists(finalWebPPath))
             {
                 finalSize = new FileInfo(finalWebPPath).Length;
@@ -317,7 +321,7 @@ public class ImageProcessorService
         }
         else if (options.ConvertToAvif)
         {
-            await RunProcessAsync(_ffmpegExecutablePath, $"-y -i \"{sourceForConversion}\" -c:v libaom-av1 -still-picture 1 -crf 35 -b:v 0 -cpu-used 4 -threads 8 \"{finalAvifPath}\"", cancellationToken);
+            await RunProcessAsync(_ffmpegExecutablePath, $"-y -i \"{sourceForConversion}\" -c:v libaom-av1 -still-picture 1 -crf {avifCrf} -b:v 0 -cpu-used 4 -threads 8 \"{finalAvifPath}\"", cancellationToken);
             if (File.Exists(finalAvifPath))
             {
                 finalSize = new FileInfo(finalAvifPath).Length;

--- a/ImageProcessor.Core/ProcessingOptions.cs
+++ b/ImageProcessor.Core/ProcessingOptions.cs
@@ -25,5 +25,7 @@ public record ProcessingOptions(
     bool ApplyUpscale,
     bool DeleteSourceFile,
     bool IncludeWebPFiles,
-    bool IncludeAvifFiles
+    bool IncludeAvifFiles,
+    int WebPQuality = 80,
+    int AvifQuality = 70
 );

--- a/ImageProcessor.Core/UserSettings.cs
+++ b/ImageProcessor.Core/UserSettings.cs
@@ -14,6 +14,8 @@ namespace ImageProcessor.Core
         public bool IncludeWebPFiles { get; set; }
         public bool IncludeAvifFiles { get; set; }
         public string SelectedModel { get; set; } = "realesrgan-x4plus";
+        public int WebPQuality { get; set; } = 80;
+        public int AvifQuality { get; set; } = 44;
         public bool IsDarkMode { get; set; }
         public RealEsrganSettings RealEsrganSettings { get; set; } = new();
     }

--- a/ImageProcessor.UI/MainWindowViewModel.cs
+++ b/ImageProcessor.UI/MainWindowViewModel.cs
@@ -346,6 +346,7 @@ public partial class MainWindowViewModel : ObservableObject
         PreviewErrorMessage = null; // Clear any previous preview error message
         _cancellationTokenSource = new CancellationTokenSource();
 
+        var userSettings = _settingsService.UserSettings;
         var options = new ProcessingOptions(
             InputFolder,
             OutputFolder,
@@ -356,7 +357,9 @@ public partial class MainWindowViewModel : ObservableObject
             ApplyUpscale,
             DeleteSourceFile,
             IncludeWebPFiles,
-            IncludeAvifFiles
+            IncludeAvifFiles,
+            userSettings.WebPQuality,
+            userSettings.AvifQuality
         );
 
         var progress = new Progress<ProcessingUpdate>(update =>

--- a/ImageProcessor.UI/ViewModels/SettingsViewModel.cs
+++ b/ImageProcessor.UI/ViewModels/SettingsViewModel.cs
@@ -11,6 +11,12 @@ namespace ImageProcessor.UI.ViewModels
         private readonly SettingsService _settingsService;
         public event EventHandler? CloseRequested;
 
+        [ObservableProperty]
+        private int _webPQuality;
+
+        [ObservableProperty]
+        private int _avifQuality;
+
         private string _realesrganArguments;
 
         [ObservableProperty]
@@ -35,6 +41,8 @@ namespace ImageProcessor.UI.ViewModels
         public SettingsViewModel()
         {
             _settingsService = new SettingsService(); // For designer
+            _webPQuality = 80;
+            _avifQuality = 44;
             _commandPreview = string.Empty;
             _realesrganArguments = new UserSettings().RealEsrganSettings.CommandArguments;
             UpdatePreview();
@@ -45,6 +53,8 @@ namespace ImageProcessor.UI.ViewModels
         public SettingsViewModel(SettingsService settingsService)
         {
             _settingsService = settingsService;
+            _webPQuality = _settingsService.UserSettings.WebPQuality;
+            _avifQuality = _settingsService.UserSettings.AvifQuality;
             _commandPreview = string.Empty; // Initialize to satisfy CS8618
             _realesrganArguments = _settingsService.UserSettings.RealEsrganSettings.CommandArguments;
             UpdatePreview();
@@ -65,6 +75,8 @@ namespace ImageProcessor.UI.ViewModels
 
         private void Save()
         {
+            _settingsService.UserSettings.WebPQuality = WebPQuality;
+            _settingsService.UserSettings.AvifQuality = AvifQuality;
             _settingsService.UserSettings.RealEsrganSettings.CommandArguments = RealEsrganArguments;
             _settingsService.Save();
             CloseRequested?.Invoke(this, EventArgs.Empty);

--- a/ImageProcessor.UI/Views/MainWindow.axaml
+++ b/ImageProcessor.UI/Views/MainWindow.axaml
@@ -23,7 +23,7 @@
         <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="5" HorizontalAlignment="Right">
             <TextBlock Text="Dark Theme"/>
             <ToggleSwitch IsChecked="{Binding IsDarkMode}" />
-            <Button Content="⚙️" Command="{Binding OpenSettingsCommand}" CommandParameter="{Binding $parent[Window]}" ToolTip.Tip="Settings" Margin="5,0,0,0"/>
+            <Button Content="⚙️" Command="{Binding OpenSettingsCommand}" CommandParameter="{Binding $parent[Window]}" ToolTip.Tip="Settings" Margin="5,0,0,0" IsEnabled="{Binding IsUiEnabled}"/>
         </StackPanel>
         
         <SplitView Grid.Row="1" 

--- a/ImageProcessor.UI/Views/SettingsView.axaml
+++ b/ImageProcessor.UI/Views/SettingsView.axaml
@@ -18,6 +18,24 @@
     </StackPanel>
 
     <StackPanel Spacing="10">
+      <TextBlock Text="Conversion Quality" Classes="h3"/>
+
+      <!-- WebP Quality Slider -->
+      <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10" VerticalAlignment="Center">
+          <TextBlock Grid.Column="0" Text="WebP Quality:"/>
+          <Slider Grid.Column="1" Minimum="1" Maximum="100" Value="{Binding WebPQuality}"/>
+          <TextBlock Grid.Column="2" Text="{Binding WebPQuality}" MinWidth="30"/>
+      </Grid>
+
+      <!-- AVIF Quality Slider -->
+      <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10" VerticalAlignment="Center">
+          <TextBlock Grid.Column="0" Text="AVIF Quality:"/>
+          <Slider Grid.Column="1" Minimum="1" Maximum="100" Value="{Binding AvifQuality}"/>
+          <TextBlock Grid.Column="2" Text="{Binding AvifQuality}" MinWidth="30"/>
+      </Grid>
+
+      <Separator Margin="0,10"/>
+
       <TextBlock Text="Real-ESRGAN Command Line Arguments" Classes="h3"/>
       <TextBlock TextWrapping="Wrap">
         Use placeholders for dynamic values:


### PR DESCRIPTION
Implements sliders to control the quality of WebP and AVIF conversions.

Adds WebPQuality and AvifQuality properties to the core processing options and user settings.

Refactors the UI to move the quality sliders from the main window to the settings window.

Disables the settings button while processing is active.